### PR TITLE
resolve:/src/App.svelte Unused CSS selectors

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,8 +25,8 @@
 		// 	(!("theme" in localStorage) &&
 		// 		window.matchMedia("(prefers-color-scheme: dark)").matches)
 		// ) {
-			document.documentElement.classList.add("dark");
-			document.documentElement.setAttribute("data-theme", "dark");
+		document.documentElement.classList.add("dark");
+		document.documentElement.setAttribute("data-theme", "dark");
 		// } else {
 		// 	document.documentElement.setAttribute("data-theme", "light");
 		// 	document.documentElement.classList.remove("dark");
@@ -141,7 +141,7 @@
 	</Route>
 </Router>
 
-<style gloabl lang="postcss">
+<style global lang="postcss">
 	@tailwind utilities;
 	@tailwind components;
 	@tailwind base;
@@ -149,12 +149,12 @@
 		display: flex;
 		flex-direction: row;
 	}
-	.theme {
-		z-index: 1000;
-		position: absolute;
-		right: 0.5%;
-		margin: 0.2em;
-		color: red;
-		max-width: fit-content;
-	}
+	/* .theme { */
+	/* 	z-index: 1000; */
+	/* 	position: absolute; */
+	/* 	right: 0.5%; */
+	/* 	margin: 0.2em; */
+	/* 	color: red; */
+	/* 	max-width: fit-content; */
+	/* } */
 </style>


### PR DESCRIPTION
resolves from https://github.com/SureshPradhana/notes-gui/issues/6
 - /src/App.svelte:140:1 Unused CSS selector "svg"
 - /src/App.svelte:148:1 Unused CSS selector "circle"
 - /src/App.svelte:152:1 Unused CSS selector ".controls"
 - /src/App.svelte:160:1 Unused CSS selector ".controls input"
 - /src/App.svelte:167:1 Unused CSS selector ".theme"